### PR TITLE
docs: remove placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,6 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 ## Content Licencing
 
-Texts and content available as [CC BY](https://creativecommons.org/licenses/by/3.0/de/).
-
-Illustrations by Maria Musterfrau, all rights reserved.
-
 ## Credits
 
 <table>


### PR DESCRIPTION
A couple of repos were generated from this template in which people forgot to update the content licensing section. Perhaps it shouldn't be included in this default at all?